### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gerlero/apt-install/security/code-scanning/1](https://github.com/gerlero/apt-install/security/code-scanning/1)

The best way to fix this issue is to explicitly add a `permissions` block at the root of the workflow, setting only the minimal permissions required for the workflow to run. In most CI jobs (such as those that only check out code and run tests), this is usually `contents: read`. If the workflow requires greater permissions for activities like publishing releases or creating PRs, those can be granted granularly. In this case, based on the provided steps, it only checks out code and runs actions—no write-back to repo or PR-related activities—so `contents: read` is sufficient.

To implement this:
- Add a `permissions:` block right after the workflow `name:` and before `on:`.
- Set `contents: read` under this block.

No additional imports, methods, or definitions are needed as this is a YAML configuration fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
