### PR TITLE
Add Ubuntu 26.04 to CI workflow matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     container: ${{ matrix.container }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-24.04-arm, ubuntu-22.04-arm]
+        os: [ubuntu-26.04, ubuntu-24.04, ubuntu-22.04, ubuntu-26.04-arm, ubuntu-24.04-arm, ubuntu-22.04-arm]
         cache: [true, false]
         include:
           - os: ubuntu-latest


### PR DESCRIPTION
Updated the CI workflow to include Ubuntu 26.04 and its ARM variants.